### PR TITLE
Scrapboxへの音声URLペースト機能の実装

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "GyaonExtension",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Chrome extension for gyaon.com",
   "icons" : {
     "128": "icons/bigicon.png"
@@ -22,7 +22,7 @@
   ],
   "content_scripts": [
     {
-      "matches" : [ "<all_urls>"],
+      "matches" : [ "https://scrapbox.io/*"],
       "js": [
         "scripts/content.js"
       ],

--- a/src/scripts/content.ts
+++ b/src/scripts/content.ts
@@ -1,0 +1,7 @@
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message.cmd === "pasteToScrapbox") {
+        const pasteText = `[  ${message.url}]`;
+        console.log(pasteText);
+        document.execCommand("insertText",false, pasteText);
+    }
+});


### PR DESCRIPTION
Scrapboxへの音声URLペースト機能を実装しました。

- ContentScriptにペースト機能(`document.execCommand("insertText")`)を実装
- バージョンを0.4.0にアップ